### PR TITLE
Change service type for openldap svc to ClusterIP.

### DIFF
--- a/openldap/openldap-service.yaml
+++ b/openldap/openldap-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: openldap
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - name: tcp-ldap
       port: 1389


### PR DESCRIPTION
- Change service type for openldap svc to ClusterIP. 