### PR TITLE
Use K8s domain names of services in the oauth2 proxy config

### DIFF
--- a/oauth2-proxy/oauth2-proxy-deployment.yaml
+++ b/oauth2-proxy/oauth2-proxy-deployment.yaml
@@ -18,8 +18,8 @@ spec:
       containers:
       - args:
         - --provider=oidc
-        - --redirect-url=http://onkar-oauth2-proxy.dev.gke.kasten.io:4180/oauth2/callback
-        - --oidc-issuer-url=http://onkar-dex.dev.gke.kasten.io:5556/dex
+        - --redirect-url=http://oauth2-proxy.pacman:4180/oauth2/callback
+        - --oidc-issuer-url=http://dex.dex:5556/dex
         - --cookie-secure=false
         - --email-domain=*
         - --upstream=http://pacman-actual.pacman:8080

--- a/oauth2-proxy/oauth2-proxy-service.yaml
+++ b/oauth2-proxy/oauth2-proxy-service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: oauth2-proxy
   namespace: pacman
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - name: http
     port: 4180


### PR DESCRIPTION
- Change service type to ClusterIP.
- Use K8s domain name of dex service in the issuer config.
- Use K8s domain name of oauth2 proxy svc in redirect-url config.