### PR TITLE
Change svc type to ClusterIP for the pacman-actual svc.

### DIFF
--- a/pacman/pacman-actual-service.yaml
+++ b/pacman/pacman-actual-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: pacman
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: 8080
       targetPort: 8080


### PR DESCRIPTION
- Change svc type to ClusterIP for the pacman-actual svc.