### PR TITLE
Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The following steps correspond to the live tutorial walkthrough, which will prov
 ## Pac-man
 1. Install via Helm
     ```
+    cd ../pacman
     helm repo add pacman https://shuguet.github.io/pacman/
     helm repo update pacman
     helm install pacman pacman/pacman -n pacman


### PR DESCRIPTION
In section Pac-man, step 8, the kubectl create command assumes the user has changed directories to the secure-pacman/pacman directory. This change makes this section just like the OpenLDAP, Dex and OAuth2 Proxy sections in changing to the target directory at the start of the section.